### PR TITLE
Basic domain server class.

### DIFF
--- a/Assets/TestScript.cs
+++ b/Assets/TestScript.cs
@@ -13,12 +13,83 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[System.Serializable]
+public class ApplicationInfo
+{
+
+    private string _name;
+    public string name
+    {
+        get { return _name ?? Application.productName; }
+        set { _name = value; }
+    }
+
+    private string _organization;
+    public string organization
+    {
+        get { return _organization ?? Application.companyName; }
+        set { _organization = value; }
+    }
+
+    public string domain;
+
+    private string _version;
+    public string version
+    {
+        get { return _version ?? Application.version; }
+        set { _version = value; }
+    }
+}
+
 public class TestScript : MonoBehaviour
 {
+    private Vircadia.DomainServer _domainServer;
+    private bool _connected = false;
+    private int _nodesSeen = 0;
+
+    public string location = "localhost";
+    public ApplicationInfo applicationInfo;
 
     void Start()
     {
         Debug.Log("Vircadia SDK native API version: " + Vircadia.Info.NativeVersion().full);
+
+        this._domainServer = new Vircadia.DomainServer(
+            appName: this.applicationInfo.name,
+            appOrganization: this.applicationInfo.organization,
+            appDomain: this.applicationInfo.domain,
+            appVersion: this.applicationInfo.version);
+
+        if (!string.IsNullOrEmpty(this.location))
+        {
+            this._domainServer.Connect(this.location);
+        }
+    }
+
+    void FixedUpdate()
+    {
+        if (!this._connected)
+        {
+            Debug.Log("[vircadia-unity-example] Connecting");
+            if (this._domainServer.Status == Vircadia.DomainServerStatus.Connected)
+            {
+                Debug.Log("[vircadia-unity-example] Successfully connected to " + this.location);
+                this._connected = true;
+            }
+        }
+        else
+        {
+            var nodes = this._domainServer.Nodes;
+            if (nodes.Length != _nodesSeen)
+            {
+                Debug.Log("[vircadia-unity-example] Updated node list:");
+                foreach (var node in nodes)
+                {
+                    Debug.Log("[vircadia-unity-example] UUID: " + node.uuid.ToString());
+                }
+                _nodesSeen = nodes.Length;
+            }
+        }
     }
 
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 TEST_RESULT = unity-test-result.xml
 PACKAGE = com.vircadia.unitysdk.tar.gz
+BUILDDIR = ./build
 
 UNITY3D = $(UNITY3D_PATH)/Editor/Unity
+
+build:
+	$(UNITY3D) -batchmode -nographics -quit -buildLinux64Player "$(BUILDDIR)/app" -logfile -
+
+run:
+	$(BUILDDIR)/app -screen-fullscreen 0 -screen-height 600 -screen-width 800 -logfile -
 
 debug:
 	$(UNITY3D) -runTests -batchmode -nographics -testPlatform playmode -testResults $(TEST_RESULT) -logfile -
@@ -25,5 +32,8 @@ clean-tests:
 clean-package:
 	-rm $(PACKAGE)
 
+clean-build:
+	-rm -rf $(BUILDDIR)
 
-.PHONY: test clean-tests
+
+.PHONY: build run debug test package docs clean-tests clean-package clean-build

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
@@ -15,29 +15,79 @@ using System.Runtime.InteropServices;
 namespace Vircadia
 {
 
+    /// <summary>
+    /// Optional fixed ports data.
+    /// </summary>
+    [System.Serializable]
     public struct Ports
     {
+        /// <summary>
+        /// UDP port for the client to listen on. (default: random port)
+        /// </summary>
         public int? listenPort;
+
+        /// <summary>
+        /// DTLS port for the client to listen on. (default: not used)
+        /// </summary>
         public int? dtlsListenPort;
     }
 
-
+    /// <summary>
+    /// Node (assignment client) data.
+    /// </summary>
     public struct Node
     {
+        /// <summary>
+        /// Type of the node.
+        /// </summary>
         public byte type;
+
+        /// <summary>
+        /// Indicated weather the node is active, or not.
+        /// </summary>
         public bool active;
+
+        /// <summary>
+        /// A human readable address/port representation.
+        /// </summary>
         public string address;
+
+        /// <summary>
+        /// A universal unique ID of the node (the string representation might not match between implementations)
+        /// </summary>
         public Guid uuid;
     }
 
+    /// <summary>
+    /// Possible states of the <see cref="P:Vircadia.Client.DomainServer">DomainServer</see> class.
+    /// </summary>
     public enum DomainServerStatus
     {
+        /// <summary>
+        /// Successfully Connected to a domain server, specified with <see cref="P:Vircadia.Client.DomainServer.Connect">Connect</see> method.
+        /// </summary>
         Connected,
+
+        /// <summary>
+        /// Not yet connected to any domain server.
+        /// </summary>
         Disconnected,
+
+        /// <summary>
+        /// Connection or initialization error.
+        /// TODO: Finer grained errors
+        /// </summary>
         Error,
+
+        /// <summary>
+        /// Native API reported connection status that this implementation does not recognize.
+        /// </summary>
         Unknown
     }
 
+    /// <summary>
+    /// Initializes the client and provides an API for domain server connection.
+    /// </summary>
     public class DomainServer
     {
 
@@ -59,6 +109,16 @@ namespace Vircadia
             }
         }
 
+        /// <summary>
+        /// Initializes the client and provides an API for domain server connection.
+        /// </summary>
+        /// <param name="ports"> Optional fixed ports to use. </param>
+        /// <param name="platformInfo"> Optional platform infomration. TODO: clarify the format. </param>
+        /// <param name="userAgent"> User agent string to use when connecting to Metaverse server (default: platform specific). </param>
+        /// <param name="appName"> Client application name, used for settings and log files (default: VircadiaClient). </param>
+        /// <param name="appOrganization"> Client application organization name, used for settings and log file directory (default: Vircadia). </param>
+        /// <param name="appDomain"> Client application domain name. (default: vircadia.com). TODO: figure out what this is for. </param>
+        /// <param name="appVersion"> Client application version. (default: native API version). </param>
         public DomainServer
         (
             Ports? ports = null,
@@ -106,6 +166,10 @@ namespace Vircadia
             }
         }
 
+        /// <summary>
+        /// Connect or jump to specified location.
+        /// </summary>
+        /// <param name="location">The address to go to: a "hifi://" address, an IP address (e.g., "127.0.0.1" or "localhost"), a file:/// address, a domain name, a named path on a domain (starts with "/"), a position or position and orientation, or a user (starts with "@").</param>
         public void Connect(string location)
         {
             IntPtr locationPtr = IntPtr.Zero;
@@ -114,6 +178,9 @@ namespace Vircadia
             DestroyUnmanaged(locationPtr, location);
         }
 
+        /// <summary>
+        /// The current status.
+        /// </summary>
         public DomainServerStatus Status
         {
             get
@@ -141,6 +208,9 @@ namespace Vircadia
             }
         }
 
+        /// <summary>
+        /// A list of connected nodes (assignment clients).
+        /// </summary>
         public Node[] Nodes
         {
             get

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
@@ -1,6 +1,6 @@
 //
 //  DomainServer.cs
-//  Scripts/Vircadia
+//  Runtime/Scripts/Vircadia
 //
 //  Created by Nshan G. on 21 Mar 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs
@@ -1,0 +1,181 @@
+//
+//  DomainServer.cs
+//  Scripts/Vircadia
+//
+//  Created by Nshan G. on 21 Mar 2022.
+//  Copyright 2022 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Vircadia
+{
+
+    public struct Ports
+    {
+        public int? listenPort;
+        public int? dtlsListenPort;
+    }
+
+
+    public struct Node
+    {
+        public byte type;
+        public bool active;
+        public string address;
+        public Guid uuid;
+    }
+
+    public enum DomainServerStatus
+    {
+        Connected,
+        Disconnected,
+        Error,
+        Unknown
+    }
+
+    public class DomainServer
+    {
+
+        private int _context;
+
+        static void CreateUnmanaged(ref IntPtr param, string value)
+        {
+            if (value != null)
+            {
+                param = Marshal.StringToCoTaskMemUTF8(value);
+            }
+        }
+
+        static void DestroyUnmanaged(IntPtr param, string value)
+        {
+            if (value != null)
+            {
+                Marshal.FreeCoTaskMem(param);
+            }
+        }
+
+        public DomainServer
+        (
+            Ports? ports = null,
+            string platformInfo = null,
+            string userAgent = null,
+            string appName = null,
+            string appOrganization = null,
+            string appDomain = null,
+            string appVersion = null
+        )
+        {
+            var parameters = VircadiaNative.Client.vircadia_context_defaults();
+            if (ports != null)
+            {
+                if (ports.Value.listenPort != null)
+                {
+                    parameters.listenPort = ports.Value.listenPort.Value;
+                }
+
+                if (ports.Value.dtlsListenPort != null)
+                {
+                    parameters.dtlsListenPort = ports.Value.dtlsListenPort.Value;
+                }
+            }
+
+            CreateUnmanaged(ref parameters.platform_info, platformInfo);
+            CreateUnmanaged(ref parameters.user_agent, userAgent);
+
+            this._context = VircadiaNative.Client.vircadia_create_context(parameters);
+
+            DestroyUnmanaged(parameters.platform_info, platformInfo);
+            DestroyUnmanaged(parameters.user_agent, userAgent);
+        }
+
+        ~DomainServer()
+        {
+            if (this._context < 0)
+            {
+                return;
+            }
+
+            if (VircadiaNative.Client.vircadia_destroy_context(this._context) < 0)
+            {
+                // TODO: report error somehow
+            }
+        }
+
+        public void Connect(string location)
+        {
+            IntPtr locationPtr = IntPtr.Zero;
+            CreateUnmanaged(ref locationPtr, location);
+            VircadiaNative.Client.vircadia_connect(this._context, locationPtr);
+            DestroyUnmanaged(locationPtr, location);
+        }
+
+        public DomainServerStatus Status
+        {
+            get
+            {
+                if (this._context < 0)
+                {
+                    return DomainServerStatus.Error;
+                }
+
+                int nativeStatus = VircadiaNative.Client.vircadia_connection_status(this._context);
+                if (nativeStatus < 0)
+                {
+                    return DomainServerStatus.Error;
+                }
+                else if (nativeStatus == 0)
+                {
+                    return DomainServerStatus.Disconnected;
+                }
+                else if (nativeStatus == 1)
+                {
+                    return DomainServerStatus.Connected;
+                }
+
+                return DomainServerStatus.Unknown;
+            }
+        }
+
+        public Node[] Nodes
+        {
+            get
+            {
+                if(VircadiaNative.Client.vircadia_update_nodes(this._context) < 0)
+                {
+                    return null;
+                }
+
+                int count = VircadiaNative.Client.vircadia_node_count(this._context);
+
+                if (count < 0)
+                {
+                    return null;
+                }
+
+                Node[] values = new Node[count];
+
+                byte[] uuidBytes = new byte[16];
+                for (int i = 0; i < count ; ++i)
+                {
+                    IntPtr nativeUUID = VircadiaNative.Client.vircadia_node_uuid(this._context, i);
+                    if (nativeUUID == IntPtr.Zero)
+                    {
+                        return null;
+                    }
+
+                    Marshal.Copy(nativeUUID, uuidBytes, 0, uuidBytes.Length);
+                    values[i].uuid = new Guid(uuidBytes);
+                    // TODO fill other node fields
+                }
+
+                return values;
+            }
+        }
+
+    }
+}

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs.meta
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/DomainServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70a51652328183a078080d74aa103960
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Info.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Info.cs
@@ -1,6 +1,6 @@
 //
 //  Info.cs
-//  Scripts/Vircadia
+//  Runtime/Scripts/Vircadia
 //
 //  Created by Nshan G. on 18 Feb 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs
@@ -1,6 +1,6 @@
 //
 //  Client.cs
-//  Scripts/Vircadia/Native
+//  Runtime/Scripts/Vircadia/Native
 //
 //  Created by Nshan G. on 21 Mar 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs
@@ -1,0 +1,61 @@
+//
+//  Client.cs
+//  Scripts/Vircadia/Native
+//
+//  Created by Nshan G. on 21 Mar 2022.
+//  Copyright 2022 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace VircadiaNative
+{
+
+    public struct client_info
+    {
+        public IntPtr name;
+        public IntPtr organization;
+        public IntPtr domain;
+        public IntPtr version;
+    }
+
+    public struct context_params
+    {
+        public int listenPort;
+        public int dtlsListenPort;
+        public IntPtr platform_info;
+        public IntPtr user_agent;
+        public client_info info;
+    }
+
+    public static class Client
+    {
+        [DllImport(DLLConstants.Import)]
+        public static extern context_params vircadia_context_defaults();
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_create_context(context_params _);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_destroy_context(int context);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_connect(int context, IntPtr location);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_connection_status(int context);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_update_nodes(int context);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern int vircadia_node_count(int context);
+
+        [DllImport(DLLConstants.Import)]
+        public static extern IntPtr vircadia_node_uuid(int context, int index);
+    }
+}

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs.meta
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Client.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d12dd092f1e2e33e78c5b2029f79b2eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Common.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Common.cs
@@ -1,6 +1,6 @@
 //
 //  Common.cs
-//  Scripts/Vircadia/Native
+//  Runtime/Scripts/Vircadia/Native
 //
 //  Created by Nshan G. on 18 Feb 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Info.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Info.cs
@@ -26,7 +26,7 @@ namespace VircadiaNative
 
     public static class Info
     {
-      [DllImport(DLLConstants.Import)]
-      public static extern IntPtr vircadia_client_version();
+        [DllImport(DLLConstants.Import)]
+        public static extern IntPtr vircadia_client_version();
     }
 }

--- a/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Info.cs
+++ b/Packages/com.vircadia.unitysdk/Runtime/Scripts/Vircadia/Native/Info.cs
@@ -1,6 +1,6 @@
 //
 //  Info.cs
-//  Scripts/Vircadia/Native
+//  Runtime/Scripts/Vircadia/Native
 //
 //  Created by Nshan G. on 18 Feb 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/Common.cs
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/Common.cs
@@ -1,6 +1,6 @@
 //
 //  Common.cs
-//  UnityTests
+//  Tests/Runtime
 //
 //  Created by Nshan G. on 18 Feb 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs
@@ -1,0 +1,55 @@
+//
+//  DomainServer.cs
+//  Tests/Runtime
+//
+//  Created by Nshan G. on 22 Mar 2022.
+//  Copyright 2022 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class DomainServer
+{
+    [UnityTest]
+    public IEnumerator ConnectionPasses()
+    {
+
+        var domainServer = new Vircadia.DomainServer();
+        domainServer.Connect("localhost");
+        for (int i = 0; i < 10; ++i)
+        {
+            var status = domainServer.Status;
+            if (status == Vircadia.DomainServerStatus.Connected)
+            {
+                var nodes = domainServer.Nodes;
+                Assert.AreNotEqual(nodes, null);
+                for (int one = 0; one < nodes.Length - 1; ++one)
+                {
+                    for (int other = one + 1; other < nodes.Length; ++other)
+                    {
+                        Assert.AreNotEqual(nodes[one], nodes[other]);
+                    }
+                }
+
+                if (nodes.Length > 3)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                Assert.AreEqual(status, Vircadia.DomainServerStatus.Disconnected);
+            }
+
+            yield return new WaitForSeconds(1);
+        }
+
+    }
+}

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs
@@ -34,7 +34,7 @@ public class DomainServer
                 {
                     for (int other = one + 1; other < nodes.Length; ++other)
                     {
-                        Assert.AreNotEqual(nodes[one], nodes[other]);
+                        Assert.AreNotEqual(nodes[one].uuid, nodes[other].uuid);
                     }
                 }
 

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs.meta
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/DomainServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1721f9fce0adabeab21c119f7bca637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/Info.cs
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/Info.cs
@@ -1,6 +1,6 @@
 //
 //  Info.cs
-//  UnityTests
+//  Tests/Runtime
 //
 //  Created by Nshan G. on 18 Feb 2022.
 //  Copyright 2022 Vircadia contributors.

--- a/Packages/com.vircadia.unitysdk/Tests/Runtime/Info.cs
+++ b/Packages/com.vircadia.unitysdk/Tests/Runtime/Info.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 public class Info
 {
     [Test]
-    public void BasicSimplePasses()
+    public void VersionPasses()
     {
         var version = Vircadia.Info.NativeVersion();
         Log.WriteLine("Native Client API version is " + version.full);

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/TestScene.unity
+    guid: b6c79009a4942161fab845b5f98bbfdb
   m_configObjects: {}


### PR DESCRIPTION
- [x] Native C API wrapper.
- [x] Unit Test.
- [x] Example.
- [x] Documentation.

This PR integrates APIs from https://github.com/vircadia/vircadia/pull/1623. The unit test similarly will try to connect to localhost if available and check node UUIDs.

The test script component in test object in test scene now has a location field that can be set to domain server address. It will automatically connect when run, and log connection status and node UUIDs.
